### PR TITLE
Fix Portuguese and Chinese and update languages,

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,7 @@ cd $ABSPATH
 
 WKHTML=./wkhtmltox/bin/wkhtmltopdf
 
-LANGUAGES=( en af de ar be bg ca cs da et el es eo fa eu fr gl ko sr hr id it he lt hu nl ja nb pl pt-br pt-pt ro ru sk sl fi sv vi tr uk zh-hans zh-hant )
-NID=36546
+LANGUAGES=( en af ar be bg ca cs da de et el es eo fa eu sq fo fr gl ko sr cy hi hr id it he lt hu nl ja nb pl pt_BR pt_PT ro ru sk sl fi sv th vi tr uk zh-Hans zh-Hant ig )
 NID3=278625
 
 LANGUAGE_COUNT=${#LANGUAGES[@]}


### PR DESCRIPTION
to all the handbook can get translated to, as of May 15, 2019.
This actually adds Albanian, Faeroese, Welsh, Hindi, Thai and Igbo.
And it changes the order to that of musescore.org